### PR TITLE
Display country&city and use geolite2 instead of geoip2

### DIFF
--- a/geoip/GeoIp2.php
+++ b/geoip/GeoIp2.php
@@ -25,7 +25,7 @@ class GeoIp2 extends AbstractReader
             if (!strlen($accountId) || !strlen($licenseKey)) {
                 throw new Exception('Missing GeoIP account ID or license key');
             }
-            $client = new Client((int)$accountId, $licenseKey);
+            $client = new Client((int)$accountId, $licenseKey, ['en'], ['host' => 'geolite.info']);
             $this->record = $client->city($ip);
         }
         catch (Exception $ex) {

--- a/language/en/default.php
+++ b/language/en/default.php
@@ -46,6 +46,7 @@ return [
 
     'column_id' => 'ID',
     'column_ip' => 'IP',
+    'column_country_city' => 'Country City',
     'column_customer' => 'Customer',
     'column_access' => 'Access',
     'column_browser' => 'Browser',

--- a/models/config/pagevisit.php
+++ b/models/config/pagevisit.php
@@ -51,8 +51,8 @@ return [
                 'searchable' => true,
             ],
             'country_city' => [
-                'label' => 'lang:admin::lang.label_name',
-                'type' => 'text',
+                'label' => 'lang:igniterlabs.visitortracker::default.column_country_city',
+                'relation' => 'geoip',
                 'sortable' => false,
             ],
             'page_views' => [


### PR DESCRIPTION
1. For issue https://github.com/igniter-labs/ti-ext-visitortracker/issues/4, use the free geolite2 instead of the geoip2 by passing an argument when init the client.

2. Display the country-city name for the request.
![image](https://user-images.githubusercontent.com/12481493/190930462-48ab424d-ae30-4a1f-8cdf-9e0c1a5f262d.png)
